### PR TITLE
max for int in bytes it's around 3.6 Gb it's not enoungh

### DIFF
--- a/src/main/java/net/tjeerd/onedrive/json/folder/Data.java
+++ b/src/main/java/net/tjeerd/onedrive/json/folder/Data.java
@@ -14,7 +14,7 @@ public class Data  {
     private String     name;
     private String     parent_id;
     private SharedWith shared_with;
-    private int        size;
+    private long        size;
     private String     source;
     private String     type;
     private String     updated_time;
@@ -123,11 +123,11 @@ public class Data  {
         this.shared_with = sharedWith;
     }
     
-    public int getSize() {
+    public long getSize() {
         return this.size;
     }
     
-    public void setSize(int size) {
+    public void setSize(long size) {
         this.size = size;
     }
     


### PR DESCRIPTION
I changed size variable type from int to long, because OneDrive sends file/folder size in bytes, and max value for int is  3 612 163 635 bytes = 3 612.16363 megabytes, not enough. 
